### PR TITLE
fix message Id property

### DIFF
--- a/lab-2/generic-backend-microservice/app.py
+++ b/lab-2/generic-backend-microservice/app.py
@@ -7,7 +7,7 @@ SERVICE_NAME = os.environ['SERVICE_NAME']
 
 def process(event):
     print('{} process: {}'.format(SERVICE_NAME, event))
-    message_id = event['id']
+    message_id = event['MessageId']
 
     # will fail randomly to show the Amazon SNS redelivery feature
     if random.choice([True, False]):


### PR DESCRIPTION
Problem with 'id' key within the event for the backend functions in lab2:

```
'id': KeyError
Traceback (most recent call last):
  File "/var/task/app.py", line 29, in lambda_handler
    process(request_body)
  File "/var/task/app.py", line 10, in process
    message_id = event['id']
KeyError: 'id'
```

Replace 'id' with 'MessageId'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.