### PR TITLE
fix: cfn-lint installation

### DIFF
--- a/code/lab-0/configureCloud9.sh
+++ b/code/lab-0/configureCloud9.sh
@@ -2,7 +2,7 @@
 sudo yum update -y
 
 # Install cf-lint
-sudo pip install cfn-lint
+pip install cfn-lint --use-feature=2020-resolver
 
 #cleanup
 rm -fr ~/environment/wild-rydes-async-messaging/workshop/


### PR DESCRIPTION
*Issue #, if available:*
#29 

*Description of changes:*
Changed the way that the package installs cfn-lint, by removing `sudo`. Also addressed the warning that appears when you install without the `--use-feature=2020-resolver` flag

> After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.
> 
> We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.
> 
> awscli 1.19.94 requires botocore==1.20.94, but you'll have botocore 1.20.97 which is incompatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
