### PR TITLE
fix: added hint to cleanup inline policies before tearing down stack

### DIFF
--- a/workshop/content/fan-out-and-message-filtering/clean-up/clean-up.md
+++ b/workshop/content/fan-out-and-message-filtering/clean-up/clean-up.md
@@ -6,7 +6,11 @@ pre = "8 "
 
 In this step, we will clean up all resources, we created during this lab, so that no further cost will occur.
 
-#### 1. Delete the AWS SAM template
+#### 1. Delete the previously created IAM Inline Policies
+
+In your Amazon IAM console, select **[Roles](https://console.aws.amazon.com/iamv2/home#/roles)** in the left navigation. In the search field, enter "async-msg". Open all matching roles and delete the previously created inline policies by clicking the "x" right to the policy name.
+
+#### 2. Delete the AWS SAM template
 
 In your Cloud9 IDE, run the following command to delete the resources we created with our AWS SAM template:
 
@@ -18,7 +22,7 @@ aws cloudformation delete-stack \
 {{< /highlight >}}
 
 
-#### 2. Delete the AWS Lambda created Amazon CloudWatch Log Group
+#### 3. Delete the AWS Lambda created Amazon CloudWatch Log Group
 
 Follow **[this deep link](https://console.aws.amazon.com/cloudwatch/home?#logs:prefix=/aws/lambda/wild-rydes)** to list the **Amazon CloudWatch Log Groups** with the name `/aws/lambda/wild-rydes`, AWS Lambda created during this lab. Select the Amazon CloudWatch Log Group and choose **Delete log group** from the **Actions** menu.
 

--- a/workshop/content/topic-queue-chaining-and-load-balancer/clean-up/clean-up.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/clean-up/clean-up.md
@@ -6,7 +6,11 @@ pre = "8 "
 
 In this step, we will clean up all resources, we created during this lab, so that no further cost will occur.
 
-#### 1. Delete the AWS SAM template
+#### 1. Delete the previously created IAM Inline Policies
+
+In your Amazon IAM console, select **[Roles](https://console.aws.amazon.com/iamv2/home#/roles)** in the left navigation. In the search field, enter "async-msg". Open all matching roles and delete the previously created inline policies by clicking the "x" right to the policy name.
+
+#### 2. Delete the AWS SAM template
 
 In your Cloud9 IDE, run the following command to delete the resources we created with our AWS SAM template:
 
@@ -18,7 +22,7 @@ aws cloudformation delete-stack \
 {{< /highlight >}}
 
 
-#### 2. Delete the AWS Lambda created Amazon CloudWatch Log Group
+#### 3. Delete the AWS Lambda created Amazon CloudWatch Log Group
 
 Follow **[this deep link](https://console.aws.amazon.com/cloudwatch/home?#logs:prefix=/aws/lambda/wild-rydes-async-msg-2)** to list all **Amazon CloudWatch Log Groups** with the prefix `/aws/lambda/wild-rydes-async-msg-2`, AWS Lambda created during this lab. Select all the Amazon CloudWatch Log Group one after each other and choose **Delete log group** from the **Actions** menu.
 


### PR DESCRIPTION
*Issue #, if available:*

Added a hint regarding cleaning up previously created inline policies. Without deleting the policies beforehand, the CloudFormation teardown did not work for me.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
