### PR TITLE
chg: removed reference to "Quick Create Queue"

### DIFF
--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-accounting-service-subscription/create-customer-accounting-service-subscription-console.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-accounting-service-subscription/create-customer-accounting-service-subscription-console.md
@@ -12,7 +12,7 @@ In your **[Amazon SQS console](https://console.aws.amazon.com/sqs/home?)**, sele
 ![Step 1](step-1-console.png)
 {{% /expand%}}
 
-Enter `CustomerAccountingServiceQueue` as **Queue Name**, make sure **Standard Queue** is highlighted and click **Quick-Create Queue**.
+Enter `CustomerAccountingServiceQueue` as **Queue Name**, make sure **Standard Queue** is highlighted and click **Create Queue**.
 
 {{%expand "Screenshot" %}}
 ![Step 2](step-2-console.png)

--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-notification-service-subscription/create-customer-notification-service-subscription-console.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-notification-service-subscription/create-customer-notification-service-subscription-console.md
@@ -12,7 +12,7 @@ In your **[Amazon SQS console](https://console.aws.amazon.com/sqs/home?)**, sele
 ![Step 1](step-1-console.png)
 {{% /expand%}}
 
-Enter `CustomerNotificationServiceQueue` as **Queue Name**, make sure **Standard Queue** is highlighted and click **Quick-Create Queue**.
+Enter `CustomerNotificationServiceQueue` as **Queue Name**, make sure **Standard Queue** is highlighted and click **Create Queue**.
 
 {{%expand "Detailed description" %}}
 ![Step 2](step-2-console.png)

--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-extraordinary-rides-service-subscription/create-extraordinary-rides-service-subscription-console.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-extraordinary-rides-service-subscription/create-extraordinary-rides-service-subscription-console.md
@@ -12,7 +12,7 @@ In your **[Amazon SQS console](https://console.aws.amazon.com/sqs/home?)**, sele
 ![Step 1](step-1-console.png)
 {{% /expand%}}
 
-Enter `ExtraordinaryRidesServiceQueue` as **Queue Name**, make sure **Standard Queue** is highlighted and click **Quick-Create Queue**.
+Enter `ExtraordinaryRidesServiceQueue` as **Queue Name**, make sure **Standard Queue** is highlighted and click **Create Queue**.
 
 {{%expand "Detailed description" %}}
 ![Step 2](step-2-console.png)


### PR DESCRIPTION
*Issue #, if available:*

Removed reference to "Quick Create Queue" button. AFAIK it does not exist anymore and "Create Queue" with default settings resembles the same settings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
