### PR TITLE
Lab3: Use return address

### DIFF
--- a/code/lab-3/generic-unicorn-management-service/app.py
+++ b/code/lab-3/generic-unicorn-management-service/app.py
@@ -6,7 +6,6 @@ import random
 import time
 
 SERVICE_NAME = os.environ['SERVICE_NAME']
-QUEUE_URL = os.environ['QUEUE_URL']
 
 config = Config(connect_timeout=5, read_timeout=5, retries={'max_attempts': 1})
 sqs = boto3.client('sqs', config=config)
@@ -32,8 +31,11 @@ def lambda_handler(event, context):
         'quote': random.randint(0,100)
     })
 
+    # extract return address from the payload
+    responseQueueUrl = message['response-queue-url']
+
     response = sqs.send_message(
-        QueueUrl = QUEUE_URL,
+        QueueUrl = responseQueueUrl,
         MessageBody = response_message
     )
 

--- a/code/lab-3/request-for-quotes-service/app.py
+++ b/code/lab-3/request-for-quotes-service/app.py
@@ -6,6 +6,7 @@ import uuid
 
 TABLE_NAME = os.environ['TABLE_NAME']
 TOPIC_ARN = os.environ['TOPIC_ARN']
+RESPONSE_QUEUE_URL = os.environ['RESPONSE_QUEUE_URL']
 
 config = Config(connect_timeout=5, read_timeout=5, retries={'max_attempts': 1})
 dynamodb = boto3.client('dynamodb', config=config)
@@ -29,6 +30,7 @@ def lambda_handler(event, context):
 
     rfq_id = str(uuid.uuid4())
     request['rfq-id'] = rfq_id
+    request['response-queue-url'] = RESPONSE_QUEUE_URL
 
     response = dynamodb.put_item(
         TableName = TABLE_NAME, 

--- a/code/lab-3/template.yaml
+++ b/code/lab-3/template.yaml
@@ -23,6 +23,7 @@ Resources:
         Variables:
           TABLE_NAME: !Ref RidesBookingTable
           TOPIC_ARN: !Ref RequestForQuotesTopic
+          RESPONSE_QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - DynamoDBCrudPolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             TableName:
@@ -90,12 +91,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource1
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -109,12 +109,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource2
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -128,12 +127,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource3
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -147,12 +145,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource4
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -166,12 +163,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource5
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -185,12 +181,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource6
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -204,12 +199,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource7
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -223,12 +217,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource8
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -242,12 +235,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource9
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS
@@ -261,12 +253,11 @@ Resources:
       Environment:
         Variables:
           SERVICE_NAME: UnicornManagementResource10
-          QUEUE_URL: !Ref RequestForQuotesResponseQueue
       Policies:
         - AWSLambdaExecute
         - SQSSendMessagePolicy: # https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
             QueueName:
-              !GetAtt RequestForQuotesResponseQueue.QueueName
+              '*-RequestForQuotesResponseQueue-*'
       Events:
         SqsJobQueue:
           Type: SNS


### PR DESCRIPTION
Use return address in scatter-gather lab in order to decouple the subscriber components from the response queue

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
