### PR TITLE
fix: reverted lab-4 runtime to python3.7

### DIFF
--- a/code/lab-4/template.yaml
+++ b/code/lab-4/template.yaml
@@ -7,7 +7,7 @@ Description: >
 Globals:
   Function:
     Timeout: 3
-    Runtime: python3.9
+    Runtime: python3.7
     MemorySize: 512
     Tags:
       project: wild-rydes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reverting function runtime for lab-4 to v3.7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
