### PR TITLE
Paths should be under the `code` subfolder

### DIFF
--- a/workshop/content/fan-out-and-message-filtering/bootstrap-initial-state/bootstrap-initial-state.md
+++ b/workshop/content/fan-out-and-message-filtering/bootstrap-initial-state/bootstrap-initial-state.md
@@ -21,7 +21,7 @@ Browse to your [AWS Cloud9 Console](https://console.aws.amazon.com/cloud9/home) 
 We provide you with an [AWS SAM](https://aws.amazon.com/serverless/sam/) template which we will use to bootstrap the initial state. In the **bash tab** (at the bottom) in you AWS Cloud9 IDE, run the following commands to build the lab code:  
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/fan-out-and-message-filtering/clean-up/clean-up.md
+++ b/workshop/content/fan-out-and-message-filtering/clean-up/clean-up.md
@@ -11,7 +11,7 @@ In this step, we will clean up all resources, we created during this lab, so tha
 In your Cloud9 IDE, run the following command to delete the resources we created with our AWS SAM template:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 aws cloudformation delete-stack \
     --stack-name wild-rydes-async-msg-1
 

--- a/workshop/content/fan-out-and-message-filtering/create-customer-accounting-service-subscription/create-customer-accounting-service-subscription-sam.md
+++ b/workshop/content/fan-out-and-message-filtering/create-customer-accounting-service-subscription/create-customer-accounting-service-subscription-sam.md
@@ -6,7 +6,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-1/template.yaml`. In the **Resources** section, uncomment the Amazon SNS event source for the **CustomerAccountingFunction**. You can find the AWS SAM documentation to do so **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sns.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-1/template.yaml`. In the **Resources** section, uncomment the Amazon SNS event source for the **CustomerAccountingFunction**. You can find the AWS SAM documentation to do so **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sns.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```yaml
@@ -28,7 +28,7 @@ Events:
 Run the following command to build the lab again, after we have added the Amazon SNS subscription:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/fan-out-and-message-filtering/create-customer-notification-service-subscription/create-customer-notification-service-subscription-sam.md
+++ b/workshop/content/fan-out-and-message-filtering/create-customer-notification-service-subscription/create-customer-notification-service-subscription-sam.md
@@ -6,7 +6,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-1/template.yaml`. In the **Resources** section, uncomment the Amazon SNS event source for the **CustomerNotificationFunction**. You can find the AWS SAM documentation to do so **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sns.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-1/template.yaml`. In the **Resources** section, uncomment the Amazon SNS event source for the **CustomerNotificationFunction**. You can find the AWS SAM documentation to do so **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sns.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```yaml
@@ -27,7 +27,7 @@ Events:
 Run the following command to build the lab again, after we have added the Amazon SNS subscription:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/fan-out-and-message-filtering/create-extraordinary-rides-service-subscription/create-extraordinary-rides-service-subscription-sam.md
+++ b/workshop/content/fan-out-and-message-filtering/create-extraordinary-rides-service-subscription/create-extraordinary-rides-service-subscription-sam.md
@@ -6,7 +6,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-1/template.yaml`. In the **Resources** section, add the definition for the Amazon SNS subscription for the **ExtraordinaryRidesService**. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-1/template.yaml`. In the **Resources** section, add the definition for the Amazon SNS subscription for the **ExtraordinaryRidesService**. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html)**.
 
 {{% notice tip %}}
 Don't overlook to create the subscription filter policy!
@@ -41,7 +41,7 @@ Events:
 Run the following command to build the lab again, after we have added the Amazon SNS subscription:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/fan-out-and-message-filtering/create-sns-topic/create-sns-topic-sam.md
+++ b/workshop/content/fan-out-and-message-filtering/create-sns-topic/create-sns-topic-sam.md
@@ -7,7 +7,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-1/template.yaml`. In the **Resources** section, add the definition for an Amazon SNS topic with the name RideCompletionTopic. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-1/template.yaml`. In the **Resources** section, add the definition for an Amazon SNS topic with the name RideCompletionTopic. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```
@@ -28,7 +28,7 @@ In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-asy
 Run the following command to build the lab again, after we have added the Amazon SNS topic:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 sam build
 
 {{< /highlight >}}

--- a/workshop/content/fan-out-and-message-filtering/update-unicorn-management-service/update-unicorn-management-service-sam.md
+++ b/workshop/content/fan-out-and-message-filtering/update-unicorn-management-service/update-unicorn-management-service-sam.md
@@ -7,7 +7,7 @@ hidden = true
 
 #### 1. Grant additional IAM permissions to Lambda
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-1/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one policies entry called **DynamoDBCrudPolicy**. Directly below, add a policy entry which grants Amazon SNS publish message permission. You can look up the supported policies **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-1/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one policies entry called **DynamoDBCrudPolicy**. Directly below, add a policy entry which grants Amazon SNS publish message permission. You can look up the supported policies **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)**.
 
 {{%expand "Cheat Sheet" %}}
 
@@ -25,7 +25,7 @@ In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-asy
 
 #### 2. Provide the Amazon SNS topic ARN to Lambda
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-1/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one environment variables entry called **TABLE_NAME**. Directly below, add an additional variable with the key **TOPIC_ARN** and the corresponding value.  
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-1/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one environment variables entry called **TABLE_NAME**. Directly below, add an additional variable with the key **TOPIC_ARN** and the corresponding value.  
 
 {{%expand "Cheat Sheet" %}}
 
@@ -42,7 +42,7 @@ TOPIC_ARN: !Ref RideCompletionTopic
 
 #### 3. Update your Lambda function to call Amazon SNS
 
-In your Cloud9 IDE, open the Python based AWS Lambda function `wild-rydes-async-messaging/lab-1/unicorn-management-service/app.py`.  
+In your Cloud9 IDE, open the Python based AWS Lambda function `wild-rydes-async-messaging/code/lab-1/unicorn-management-service/app.py`.  
 Add the definition of the sns client directly after the dynamodb client:  
 
 {{%expand "Cheat Sheet" %}}
@@ -82,7 +82,7 @@ After the put item DynamoDB statement and before we are sending the response bac
 Run the following command to build the lab again, after we have added the additional policy:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-1
+cd ~/environment/wild-rydes-async-messaging/code/lab-1
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/orchestration-and-coordination/bootstrap-initial-state/bootstrap-initial-state.md
+++ b/workshop/content/orchestration-and-coordination/bootstrap-initial-state/bootstrap-initial-state.md
@@ -18,7 +18,7 @@ Browse to your [AWS Cloud9 Console](https://console.aws.amazon.com/cloud9/home) 
 We provide you with an [AWS SAM](https://aws.amazon.com/serverless/sam/) template which we will use to bootstrap the initial state. In the **bash tab** (at the bottom) in you AWS Cloud9 IDE, run the following commands to build the lab code:  
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-4
+cd ~/environment/wild-rydes-async-messaging/code/lab-4
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/orchestration-and-coordination/clean-up/clean-up.md
+++ b/workshop/content/orchestration-and-coordination/clean-up/clean-up.md
@@ -11,7 +11,7 @@ In this step, we will clean up all resources we created during the lab to preven
 In your Cloud9 IDE, run the following command to delete the resources we created with our AWS SAM template:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-4
+cd ~/environment/wild-rydes-async-messaging/code/lab-4
 sam delete --stack-name wild-rydes-async-msg-4
 {{< /highlight >}}
 

--- a/workshop/content/scatter-gather/bootstrap-initial-state.md
+++ b/workshop/content/scatter-gather/bootstrap-initial-state.md
@@ -25,7 +25,7 @@ Browse to your [AWS Cloud9 Console](https://console.aws.amazon.com/cloud9/home) 
 We provide you with an [AWS SAM](https://aws.amazon.com/serverless/sam/) template which we will use to bootstrap the initial state. In the **bash tab** (at the bottom) in you AWS Cloud9 IDE, run the following commands to build the lab code:  
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-3
+cd ~/environment/wild-rydes-async-messaging/code/lab-3
 sam build
 {{< /highlight >}}
 

--- a/workshop/content/scatter-gather/cleanup/clean-up.md
+++ b/workshop/content/scatter-gather/cleanup/clean-up.md
@@ -12,7 +12,7 @@ In this step, we will clean up all resources, we created during this lab, so tha
 In your Cloud9 IDE, run the following command to delete the resources we created with our AWS SAM template:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-3
+cd ~/environment/wild-rydes-async-messaging/code/lab-3
 aws cloudformation delete-stack \
     --stack-name wild-rydes-async-msg-3
 

--- a/workshop/content/topic-queue-chaining-and-load-balancer/bootstrap-initial-state/bootstrap-initial-state.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/bootstrap-initial-state/bootstrap-initial-state.md
@@ -22,7 +22,7 @@ Browse to your [AWS Cloud9 Console](https://console.aws.amazon.com/cloud9/home) 
 We provide you with an [AWS SAM](https://aws.amazon.com/serverless/sam/) template which we will use to bootstrap the initial state. In the **bash tab** (at the bottom) in you **AWS Cloud9 IDE**, run the following commands to build the lab code:  
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 sam build
 
 {{< /highlight >}}

--- a/workshop/content/topic-queue-chaining-and-load-balancer/clean-up/clean-up.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/clean-up/clean-up.md
@@ -11,7 +11,7 @@ In this step, we will clean up all resources, we created during this lab, so tha
 In your Cloud9 IDE, run the following command to delete the resources we created with our AWS SAM template:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 aws cloudformation delete-stack \
     --stack-name wild-rydes-async-msg-2
 

--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-accounting-service-subscription/create-customer-accounting-service-subscription-sam.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-accounting-service-subscription/create-customer-accounting-service-subscription-sam.md
@@ -6,7 +6,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SQS queue with the name **CustomerAccountingServiceQueue**, the **CustomerAccountingService** will use to consume messages from. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SQS queue with the name **CustomerAccountingServiceQueue**, the **CustomerAccountingService** will use to consume messages from. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```yaml
@@ -86,7 +86,7 @@ Last but not least, we have to declare the **CustomerAccountingServiceQueue** as
 Run the following command to build the lab again, after we have added the Amazon SQS queue and the Amazon SNS subscription:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 sam build
 
 {{< /highlight >}}

--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-notification-service-subscription/create-customer-notification-service-subscription-sam.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-customer-notification-service-subscription/create-customer-notification-service-subscription-sam.md
@@ -6,7 +6,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SQS queue with the name **CustomerNotificationServiceQueue**, the **CustomerNotificationService** will use to consume messages from. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SQS queue with the name **CustomerNotificationServiceQueue**, the **CustomerNotificationService** will use to consume messages from. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```yaml
@@ -86,7 +86,7 @@ Last but not least, we have to declare the **CustomerNotificationServiceQueue** 
 Run the following command to build the lab again, after we have added the Amazon SQS queue and the Amazon SNS subscription:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 sam build
 
 {{< /highlight >}}

--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-extraordinary-rides-service-subscription/create-extraordinary-rides-service-subscription-sam.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-extraordinary-rides-service-subscription/create-extraordinary-rides-service-subscription-sam.md
@@ -6,7 +6,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SQS queue with the name **ExtraordinaryRidesServiceQueue**, the **ExtraordinaryRidesService** will use to consume messages from. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SQS queue with the name **ExtraordinaryRidesServiceQueue**, the **ExtraordinaryRidesService** will use to consume messages from. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```yaml
@@ -87,7 +87,7 @@ Last but not least, we have to declare the **ExtraordinaryRidesServiceQueue** as
 Run the following command to build the lab again, after we have added the Amazon SQS queue and the Amazon SNS subscription:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 sam build
 
 {{< /highlight >}}

--- a/workshop/content/topic-queue-chaining-and-load-balancer/create-sns-topic/create-sns-topic-sam.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/create-sns-topic/create-sns-topic-sam.md
@@ -7,7 +7,7 @@ hidden = true
 
 #### 1. Update the AWS SAM template
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SNS topic with the name RideCompletionTopic. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-2/template.yaml`. In the **Resources** section, add the definition for an Amazon SNS topic with the name RideCompletionTopic. You can find the AWS CloudFormation documentation to do so **[here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html)**.
 
 {{%expand "Cheat Sheet" %}}
 ```
@@ -28,7 +28,7 @@ In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-asy
 Run the following command to build the lab again, after we have added the Amazon SNS topic:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 sam build
 
 {{< /highlight >}}

--- a/workshop/content/topic-queue-chaining-and-load-balancer/update-unicorn-management-service/update-unicorn-management-service-sam.md
+++ b/workshop/content/topic-queue-chaining-and-load-balancer/update-unicorn-management-service/update-unicorn-management-service-sam.md
@@ -7,7 +7,7 @@ hidden = true
 
 #### 1. Grant additional IAM permissions to Lambda
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-2/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one policies entry called **DynamoDBCrudPolicy**. Directly below, add a policy entry which grants Amazon SNS publish message permission. You can look up the supported policies **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)**.
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-2/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one policies entry called **DynamoDBCrudPolicy**. Directly below, add a policy entry which grants Amazon SNS publish message permission. You can look up the supported policies **[here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)**.
 
 {{%expand "Cheat Sheet" %}}
 
@@ -25,7 +25,7 @@ In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-asy
 
 #### 2. Provide the Amazon SNS topic ARN to Lambda
 
-In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/lab-2/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one environment variables entry called **TABLE_NAME**. Directly below, add an additional variable with the key **TOPIC_ARN** and the corresponding value.  
+In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-async-messaging/code/lab-2/template.yaml`. In the **Resources** section, look for the **SubmitRideCompletionFunction** definition. It already contains one environment variables entry called **TABLE_NAME**. Directly below, add an additional variable with the key **TOPIC_ARN** and the corresponding value.  
 
 {{%expand "Cheat Sheet" %}}
 
@@ -42,7 +42,7 @@ In your Cloud9 IDE for this workshop, open the SAM template file `wild-rydes-asy
 
 #### 3. Update your Lambda function to call Amazon SNS
 
-In your Cloud9 IDE, open the Python based AWS Lambda function `wild-rydes-async-messaging/lab-2/unicorn-management-service/app.py`.  
+In your Cloud9 IDE, open the Python based AWS Lambda function `wild-rydes-async-messaging/code/lab-2/unicorn-management-service/app.py`.  
 Add the definition of the sns client directly after the dynamodb client:  
 
 {{%expand "Cheat Sheet" %}}
@@ -82,7 +82,7 @@ After the put item DynamoDB statement and before we are sending the response bac
 Run the following command to build the lab again, after we have added the additional policy:
 
 {{< highlight bash >}}
-cd ~/environment/wild-rydes-async-messaging/lab-2
+cd ~/environment/wild-rydes-async-messaging/code/lab-2
 sam build
 
 {{< /highlight >}}


### PR DESCRIPTION
*Description of changes:*
The sample commands throughout the workshop reference the `lab-*` folders as if they were at the top level of the repo, but they're actually subfolders of `code`. This is similar to the change in 84c7a102a910964375f7612b542b126566bd8e2c, which was reverted, but the code paths are not valid if the `code` folder is not included.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
